### PR TITLE
Remove unused syslog dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,11 +1,5 @@
 %%-*- mode: erlang -*-
 {sub_dirs, ["apps/flake", "rel", "deps"]}.
 
-{deps,
-	[
-    {syslog, ".*", {git, "git://github.com/JacobVorreuter/erlang_syslog.git", "master"}}
-	]
-}.
-
 {erl_opts, [debug_info]}.
 {cover_enabled, false}.


### PR DESCRIPTION
Currently it doesn't seem that flake actually uses or depends on syslog.
