### PR TITLE
Provide a meaningful default network interface

### DIFF
--- a/apps/flake/src/flake_sup.erl
+++ b/apps/flake/src/flake_sup.erl
@@ -57,7 +57,8 @@ upgrade() ->
 %% @spec init([]) -> SupervisorTree
 %% @doc supervisor callback.
 init([]) ->
-    If = flake:get_config_value(interface, "eth0"),
+    DefaultIf = flake_util:get_default_if(),
+    If = flake:get_config_value(interface, DefaultIf),
     error_logger:info_msg("starting flake with hardware address of ~p as worker id~n", [If]),
     {ok,WorkerId} = flake_util:get_if_hw_int(If),
     error_logger:info_msg("using worker id: ~p~n", [WorkerId]),

--- a/apps/flake/src/flake_util.erl
+++ b/apps/flake/src/flake_util.erl
@@ -34,19 +34,20 @@ get_default_if() ->
     Ifs = [I || {I, Props} <- SysIfs, filter_if(Props)],
     hd(Ifs).
 
+% filter network interfaces
 filter_if(Props) ->
     HwAddr = proplists:get_value(hwaddr, Props),
-    case HwAddr of
-        % We exclude interfaces without a MAC address
-        undefined ->
-            false;
-        % We exclude interfaces with a null MAC address, ex: loopback devices
-        [0,0,0,0,0,0] ->
-            false;
-        % All others are valid interfaces to pick from
-        _ ->
-            true
-    end.
+    filter_hwaddr(HwAddr).
+
+% we exclude interfaces without a MAC address
+filter_hwaddr(undefined) ->
+    false;
+% we exclude interfaces with a null MAC address, ex: loopback devices
+filter_hwaddr([0,0,0,0,0,0]) ->
+    false;
+% all others are valid interfaces to pick from
+filter_hwaddr(_) ->
+    true.
 
 %% get the mac/hardware address of the given interface as a 48-bit integer
 get_if_hw_int(undefined) ->


### PR DESCRIPTION
The code as it is today, defaults to eth0 for the network interface if one
was not provided via the config file. Added get_default_if to scan system
interfaces to find one that has a MAC address and that is not null. For ex,
loopback devices in macbooks don't have hwaddr, whereas in linux, it does
have hwaddr but its all zeros. Subject to system configuration, it
defaults to returning en0 in macbook pros and eth0 in linux systems.

This is meant to ease development scenarios. It is strongly suggested that
a proper interface is specified in production systems.